### PR TITLE
add invalid data point (Test Failure)

### DIFF
--- a/task-release-2025-07-29-115124/data_points/test__test-invalid-example.json
+++ b/task-release-2025-07-29-115124/data_points/test__test-invalid-example.json
@@ -1,0 +1,14 @@
+{
+  "instance_id": "test__test-invalid-example",
+  "repo": "test/test",
+  "base_commit": "abc123",
+  "patch": "--- a/nonexistent_file.py\n+++ b/nonexistent_file.py\n@@ -1,3 +1,3 @@\n def broken_function():\n-    return True\n+    this will cause syntax error",
+  "test_patch": "",
+  "problem_statement": "Test invalid data point",
+  "hints_text": "",
+  "created_at": "2024-01-01T00:00:00Z",
+  "version": "1.0",
+  "FAIL_TO_PASS": "[\"test_nonexistent::test_that_will_fail\"]",
+  "PASS_TO_PASS": "[\"test_nonexistent::test_that_also_fails\"]",
+  "environment_setup_commit": "abc123"
+}


### PR DESCRIPTION
This PR demonstrates validation failure for an invalid data point.

**Data Point**: `data_points/test__test-invalid-example.json`
**Expected Result**: ❌ Red status checks with clear error messages
**Invalid Because**: Broken patch that will fail to apply or pass tests